### PR TITLE
Visits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8, 3.1.2]
+        scala: [3.1.3]
         java: [temurin@17]
-        project: [rootJS, rootJVM]
+        project: [rootJVM]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -73,10 +73,6 @@ jobs:
         if: matrix.java == 'temurin@17'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck lucumaScalafmtCheck lucumaScalafixCheck
 
-      - name: scalaJSLink
-        if: matrix.project == 'rootJS'
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/scalaJSLinkerResult
-
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
 
@@ -97,11 +93,11 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/scala3')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
+        scala: [3.1.3]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,12 +12,17 @@ pull_request_rules:
   - or:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
-  - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@17, rootJS)
-  - status-success=Build and Test (ubuntu-latest, 2.13.8, temurin@17, rootJVM)
-  - status-success=Build and Test (ubuntu-latest, 3.1.2, temurin@17, rootJS)
-  - status-success=Build and Test (ubuntu-latest, 3.1.2, temurin@17, rootJVM)
+  - status-success=Build and Test (ubuntu-latest, 3.1.3, temurin@17, rootJVM)
   actions:
     merge: {}
+- name: Label lucuma-schemas PRs
+  conditions:
+  - files~=^lucuma-schemas/
+  actions:
+    label:
+      add:
+      - lucuma-schemas
+      remove: []
 - name: Label templates PRs
   conditions:
   - files~=^templates/

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,19 @@
 val clueVersion            = "0.23.1"
 val lucumaCoreVersion2     = "0.45.0"
-val lucumaCoreVersion      = "0.51.0"
+val lucumaCoreVersion      = "0.53.0"
 val munitVersion           = "0.7.29"
 val munitCatsEffectVersion = "1.0.7"
+val kittensVersion         = "3.0.0-M4"
 
-ThisBuild / tlBaseVersion       := "0.35"
-ThisBuild / tlCiReleaseBranches := Seq("main", "scala3")
-ThisBuild / crossScalaVersions  := Seq("2.13.8", "3.1.2")
+ThisBuild / tlBaseVersion       := "0.36"
+ThisBuild / tlCiReleaseBranches := Seq("main")
+ThisBuild / crossScalaVersions  := Seq("3.1.3")
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.29.0")
 
 Global / onChangedBuildSource                                        := ReloadOnSourceChanges
 ThisBuild / scalafixDependencies += "edu.gemini"                     %% "clue-generator" % clueVersion
 ThisBuild / scalafixScalaBinaryVersion                               := "2.13"
 ThisBuild / ScalafixConfig / bspEnabled.withRank(KeyRanks.Invisible) := false
-
-val scala2Version = "3.1.3"
-val allVersions   = List("3.1.3")
 
 val schemasDependencies = List(
   "org.scalameta" %% "munit"               % munitVersion           % Test,
@@ -29,39 +27,22 @@ val templates =
     .in(file("templates"))
     .enablePlugins(NoPublishPlugin)
     .settings(
-      libraryDependencies ++= {
-        if (tlIsScala3.value) {
-          Seq(
-            "edu.gemini" %% "clue-core"   % clueVersion,
-            "edu.gemini" %% "lucuma-core" % lucumaCoreVersion
-          )
-        } else {
-          Seq(
-            "edu.gemini" %% "clue-core"   % clueVersion,
-            "edu.gemini" %% "lucuma-core" % lucumaCoreVersion2
-          )
-        }
-      }
+      libraryDependencies ++= Seq(
+        "edu.gemini" %% "clue-core"   % clueVersion,
+        "edu.gemini" %% "lucuma-core" % lucumaCoreVersion
+      )
     )
 
 val lucumaSchemas =
-  projectMatrix
+  project
     .in(file("lucuma-schemas"))
     .settings(
       moduleName := "lucuma-schemas",
-      libraryDependencies ++= {
-        if (tlIsScala3.value) {
-          Seq(
-            "edu.gemini" %% "clue-core"   % clueVersion,
-            "edu.gemini" %% "lucuma-core" % lucumaCoreVersion
-          )
-        } else {
-          Seq(
-            "edu.gemini" %% "clue-core"   % clueVersion,
-            "edu.gemini" %% "lucuma-core" % lucumaCoreVersion2
-          )
-        }
-      },
+      libraryDependencies ++= Seq(
+        "edu.gemini"    %% "clue-core"   % clueVersion,
+        "edu.gemini"    %% "lucuma-core" % lucumaCoreVersion,
+        "org.typelevel" %% "kittens"     % kittensVersion
+      ),
       libraryDependencies ++= schemasDependencies,
       Compile / sourceGenerators += Def.taskDyn {
         val root    = (ThisBuild / baseDirectory).value.toURI.toString
@@ -79,6 +60,3 @@ val lucumaSchemas =
       // Include schema files from templates in jar.
       Compile / unmanagedResourceDirectories += (templates / Compile / resourceDirectory).value
     )
-    .defaultAxes(VirtualAxis.jvm, VirtualAxis.scalaPartialVersion(scala2Version))
-    .jvmPlatform(allVersions)
-    .jsPlatform(allVersions)

--- a/lucuma-schemas/src/main/scala/lucuma/schemas/decoders/VisitDecoders.scala
+++ b/lucuma-schemas/src/main/scala/lucuma/schemas/decoders/VisitDecoders.scala
@@ -1,0 +1,173 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.schemas.decoders
+
+import cats.syntax.all.*
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Decoder
+import io.circe.HCursor
+import io.circe.generic.semiauto
+import io.circe.refined.given
+import lucuma.core.enums.DatasetQaState
+import lucuma.core.enums.DatasetStage
+import lucuma.core.enums.SequenceCommand
+import lucuma.core.enums.SequenceType
+import lucuma.core.enums.StepQaState
+import lucuma.core.enums.StepStage
+import lucuma.core.model.ExecutionEvent
+import lucuma.core.model.NonNegDuration
+import lucuma.core.model.sequence.DynamicConfig
+import lucuma.core.model.sequence.StaticConfig
+import lucuma.core.model.sequence.Step
+import lucuma.core.model.sequence.StepConfig
+import lucuma.schemas.model.*
+
+import java.time.Instant
+
+trait VisitDecoders:
+  given Decoder[DatasetEvent] = Decoder.instance(c =>
+    for
+      id           <- c.downField("id").as[ExecutionEvent.Id]
+      received     <- c.downField("received").as[Instant]
+      index        <- c.downField("datasetId").downField("index").as[PosInt]
+      payload      <- c.downField("payload").as[HCursor]
+      filename     <- payload.downField("filename").as[NonEmptyString]
+      datasetStage <- payload.downField("datasetStage").as[DatasetStage]
+    yield DatasetEvent(id, received, index, filename, datasetStage)
+  )
+
+  given Decoder[SequenceEvent] = Decoder.instance(c =>
+    for
+      id       <- c.downField("id").as[ExecutionEvent.Id]
+      received <- c.downField("received").as[Instant]
+      command  <- c.downField("payload").downField("command").as[SequenceCommand]
+    yield SequenceEvent(id, received, command)
+  )
+
+  given Decoder[StepEvent] = Decoder.instance(c =>
+    for
+      id           <- c.downField("id").as[ExecutionEvent.Id]
+      received     <- c.downField("received").as[Instant]
+      payload      <- c.downField("payload").as[HCursor]
+      sequenceType <- payload.downField("sequenceType").as[SequenceType]
+      stepStage    <- payload.downField("stepStage").as[StepStage]
+    yield StepEvent(id, received, sequenceType, stepStage)
+  )
+
+  given Decoder[Dataset] = Decoder.instance(c =>
+    for
+      index    <- c.downField("id").downField("index").as[PosInt]
+      filename <- c.downField("filename").as[NonEmptyString]
+      qaState  <- c.downField("qaState").as[DatasetQaState]
+    yield Dataset(index, filename, qaState)
+  )
+
+  given Decoder[StepRecord.GmosNorth] = Decoder.instance(c =>
+    for
+      id               <- c.downField("id").as[Step.Id]
+      created          <- c.downField("created").as[Instant]
+      startTime        <- c.downField("startTime").as[Option[Instant]]
+      endTime          <- c.downField("endTime").as[Option[Instant]]
+      duration         <- c.downField("duration").as[Option[NonNegDuration]]
+      instrumentConfig <- c.downField("instrumentConfig").as[DynamicConfig.GmosNorth]
+      stepConfig       <- c.downField("stepConfig").as[StepConfig]
+      stepEvents       <- c.downField("stepEvents").as[List[StepEvent]]
+      stepQaState      <- c.downField("stepQaState").as[Option[StepQaState]]
+      datasetEvents    <- c.downField("datasetEvents").as[List[DatasetEvent]]
+      datasets         <- c.downField("datasets").as[List[Dataset]]
+    yield StepRecord.GmosNorth(
+      id,
+      created,
+      startTime,
+      endTime,
+      duration,
+      instrumentConfig,
+      stepConfig,
+      stepEvents,
+      stepQaState,
+      datasetEvents,
+      datasets
+    )
+  )
+
+  given Decoder[StepRecord.GmosSouth] = Decoder.instance(c =>
+    for
+      id               <- c.downField("id").as[Step.Id]
+      created          <- c.downField("created").as[Instant]
+      startTime        <- c.downField("startTime").as[Option[Instant]]
+      endTime          <- c.downField("endTime").as[Option[Instant]]
+      duration         <- c.downField("duration").as[Option[NonNegDuration]]
+      instrumentConfig <- c.downField("instrumentConfig").as[DynamicConfig.GmosSouth]
+      stepConfig       <- c.downField("stepConfig").as[StepConfig]
+      stepEvents       <- c.downField("stepEvents").as[List[StepEvent]]
+      stepQaState      <- c.downField("stepQaState").as[Option[StepQaState]]
+      datasetEvents    <- c.downField("datasetEvents").as[List[DatasetEvent]]
+      datasets         <- c.downField("datasets").as[List[Dataset]]
+    yield StepRecord.GmosSouth(
+      id,
+      created,
+      startTime,
+      endTime,
+      duration,
+      instrumentConfig,
+      stepConfig,
+      stepEvents,
+      stepQaState,
+      datasetEvents,
+      datasets
+    )
+  )
+
+  // We must specify a name since we have a generated name conflict here.
+  // See https://dotty.epfl.ch/docs/reference/contextual/givens.html#anonymous-givens
+  given decoderVisitGmosNorth: Decoder[Visit.GmosNorth] = Decoder.instance(c =>
+    for
+      id             <- c.downField("id").as[Visit.Id]
+      created        <- c.downField("created").as[Instant]
+      startTime      <- c.downField("startTime").as[Option[Instant]]
+      endTime        <- c.downField("endTime").as[Option[Instant]]
+      duration       <- c.downField("duration").as[Option[NonNegDuration]]
+      staticConfig   <- c.downField("staticConfigN").as[StaticConfig.GmosNorth]
+      steps          <- c.downField("steps").as[List[StepRecord.GmosNorth]]
+      sequenceEvents <- c.downField("sequenceEvents").as[List[SequenceEvent]]
+    yield Visit.GmosNorth(
+      id,
+      created,
+      startTime,
+      endTime,
+      duration,
+      staticConfig,
+      steps,
+      sequenceEvents
+    )
+  )
+
+  given decoderVisitGmosSouth: Decoder[Visit.GmosSouth] = Decoder.instance(c =>
+    for
+      id             <- c.downField("id").as[Visit.Id]
+      created        <- c.downField("created").as[Instant]
+      startTime      <- c.downField("startTime").as[Option[Instant]]
+      endTime        <- c.downField("endTime").as[Option[Instant]]
+      duration       <- c.downField("duration").as[Option[NonNegDuration]]
+      staticConfig   <- c.downField("staticConfigS").as[StaticConfig.GmosSouth]
+      steps          <- c.downField("steps").as[List[StepRecord.GmosSouth]]
+      sequenceEvents <- c.downField("sequenceEvents").as[List[SequenceEvent]]
+    yield Visit.GmosSouth(
+      id,
+      created,
+      startTime,
+      endTime,
+      duration,
+      staticConfig,
+      steps,
+      sequenceEvents
+    )
+  )
+
+  given Decoder[Visit] =
+    List[Decoder[Visit]](
+      Decoder[Visit.GmosNorth].widen,
+      Decoder[Visit.GmosSouth].widen
+    ).reduceLeft(_ or _)

--- a/lucuma-schemas/src/main/scala/lucuma/schemas/decoders/package.scala
+++ b/lucuma-schemas/src/main/scala/lucuma/schemas/decoders/package.scala
@@ -14,3 +14,4 @@ package object decoders
     with PosAngleDecoders
     with ProposalDecoders
     with ExposureTimeModeDecoders
+    with VisitDecoders

--- a/lucuma-schemas/src/main/scala/lucuma/schemas/model/Dataset.scala
+++ b/lucuma-schemas/src/main/scala/lucuma/schemas/model/Dataset.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.schemas.model
+
+import cats.Eq
+import cats.derived.*
+import eu.timepit.refined.cats.given
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.core.enums.DatasetQaState
+
+final case class Dataset protected[schemas] (
+  index:    PosInt,
+  filename: NonEmptyString,
+  qaState:  DatasetQaState
+) derives Eq

--- a/lucuma-schemas/src/main/scala/lucuma/schemas/model/ExecutionEvent.scala
+++ b/lucuma-schemas/src/main/scala/lucuma/schemas/model/ExecutionEvent.scala
@@ -1,0 +1,52 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.schemas.model
+
+import cats.Eq
+import cats.derived.*
+import eu.timepit.refined.cats.given
+import eu.timepit.refined.char.Letter
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Decoder
+import lucuma.core.enums.DatasetStage
+import lucuma.core.enums.SequenceCommand
+import lucuma.core.enums.SequenceType
+import lucuma.core.enums.StepStage
+import lucuma.core.model.*
+import lucuma.core.util.WithGid
+import monocle.Focus
+import monocle.Lens
+import org.typelevel.cats.time.given
+
+import java.time.Instant
+
+sealed trait ExecutionEvent {
+  def id: ExecutionEvent.Id
+  def received: Instant
+}
+
+final case class DatasetEvent protected[schemas] (
+  id:           ExecutionEvent.Id,
+  received:     Instant,
+  index:        PosInt,
+  filename:     NonEmptyString,
+  datasetStage: DatasetStage
+) extends ExecutionEvent
+    derives Eq
+
+final case class SequenceEvent protected[schemas] (
+  id:       ExecutionEvent.Id,
+  received: Instant,
+  command:  SequenceCommand
+) extends ExecutionEvent
+    derives Eq
+
+final case class StepEvent protected[schemas] (
+  id:           ExecutionEvent.Id,
+  received:     Instant,
+  sequenceType: SequenceType,
+  stepStage:    StepStage
+) extends ExecutionEvent
+    derives Eq

--- a/lucuma-schemas/src/main/scala/lucuma/schemas/model/StepRecord.scala
+++ b/lucuma-schemas/src/main/scala/lucuma/schemas/model/StepRecord.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.schemas.model
+
+import cats.Eq
+import cats.derived.*
+import cats.syntax.all.given
+import eu.timepit.refined.cats.given
+import lucuma.core.enums.StepQaState
+import lucuma.core.model.NonNegDuration
+import lucuma.core.model.sequence.DynamicConfig
+import lucuma.core.model.sequence.Step
+import lucuma.core.model.sequence.StepConfig
+import org.typelevel.cats.time.given
+
+import java.time.Instant
+
+sealed trait StepRecord derives Eq {
+  def created: Instant
+  def stepConfig: StepConfig
+  def stepEvents: List[StepEvent]
+  def startTime: Option[Instant]
+  def duration: Option[NonNegDuration]
+}
+
+object StepRecord {
+  final case class GmosNorth protected[schemas] (
+    id:               Step.Id,
+    created:          Instant,
+    startTime:        Option[Instant],
+    endTime:          Option[Instant],
+    duration:         Option[NonNegDuration],
+    instrumentConfig: DynamicConfig.GmosNorth,
+    stepConfig:       StepConfig,
+    stepEvents:       List[StepEvent],
+    stepQaState:      Option[StepQaState],
+    datasetEvents:    List[DatasetEvent],
+    datasets:         List[Dataset]
+  ) extends StepRecord
+      derives Eq
+
+  final case class GmosSouth protected[schemas] (
+    id:               Step.Id,
+    created:          Instant,
+    startTime:        Option[Instant],
+    endTime:          Option[Instant],
+    duration:         Option[NonNegDuration],
+    instrumentConfig: DynamicConfig.GmosSouth,
+    stepConfig:       StepConfig,
+    stepEvents:       List[StepEvent],
+    stepQaState:      Option[StepQaState],
+    datasetEvents:    List[DatasetEvent],
+    datasets:         List[Dataset]
+  ) extends StepRecord
+      derives Eq
+}

--- a/lucuma-schemas/src/main/scala/lucuma/schemas/model/Visit.scala
+++ b/lucuma-schemas/src/main/scala/lucuma/schemas/model/Visit.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.schemas.model
+
+import cats.Eq
+import cats.data.Ior
+import cats.derived.*
+import cats.syntax.all.given
+import eu.timepit.refined.cats.given
+import lucuma.core.model.NonNegDuration
+import lucuma.core.model.sequence.StaticConfig
+import lucuma.core.util.WithUid
+import lucuma.refined.*
+import monocle.Focus
+import monocle.Lens
+import monocle.Prism
+import monocle.macros.GenPrism
+import org.typelevel.cats.time.given
+
+import java.time.Instant
+
+sealed trait Visit derives Eq {
+  def id: Visit.Id
+  def created: Instant
+  def startTime: Option[Instant]
+  def endTime: Option[Instant]
+  def duration: Option[NonNegDuration]
+  def staticConfig: StaticConfig
+  def steps: List[StepRecord]
+  def sequenceEvents: List[SequenceEvent]
+}
+
+object Visit extends WithUid('v'.refined) {
+  final case class GmosNorth protected[schemas] (
+    id:             Visit.Id,
+    created:        Instant,
+    startTime:      Option[Instant],
+    endTime:        Option[Instant],
+    duration:       Option[NonNegDuration],
+    staticConfig:   StaticConfig.GmosNorth,
+    steps:          List[StepRecord.GmosNorth],
+    sequenceEvents: List[SequenceEvent]
+  ) extends Visit
+      derives Eq
+
+  final case class GmosSouth protected[schemas] (
+    id:             Visit.Id,
+    created:        Instant,
+    startTime:      Option[Instant],
+    endTime:        Option[Instant],
+    duration:       Option[NonNegDuration],
+    staticConfig:   StaticConfig.GmosSouth,
+    steps:          List[StepRecord.GmosSouth],
+    sequenceEvents: List[SequenceEvent]
+  ) extends Visit
+      derives Eq
+}

--- a/lucuma-schemas/src/test/resources/v1.json
+++ b/lucuma-schemas/src/test/resources/v1.json
@@ -1,0 +1,94 @@
+{
+  "visits": [
+    {
+      "id": "v-7d093b73-3ac7-4886-bb34-0005bcb53ba4",
+      "created": "2022-08-22T18:18:46.236929950Z",
+      "startTime": "2022-08-22T18:18:56.336Z",
+      "endTime": "2022-08-22T18:26:36.809Z",
+      "duration": {
+        "microseconds": 460473000
+      },
+      "staticConfigS": {
+        "stageMode": "FOLLOW_XY",
+        "detector": "HAMAMATSU",
+        "mosPreImaging": "IS_NOT_MOS_PRE_IMAGING"
+      },
+      "steps": [
+        {
+          "id": "s-f1214814-93c8-4cdb-848b-8a69e61fc754",
+          "created": "2022-08-22T18:19:03.230191206Z",
+          "startTime": "2022-08-22T18:26:42.092Z",
+          "endTime": "2022-08-22T18:26:36.809Z",
+          "duration": {
+            "microseconds": 0
+          },
+          "instrumentConfig": {
+            "exposure": {
+              "microseconds": 120000000
+            },
+            "readout": {
+              "xBin": "ONE",
+              "yBin": "ONE",
+              "ampCount": "THREE",
+              "ampGain": "LOW",
+              "ampReadMode": "SLOW"
+            },
+            "dtax": "ZERO",
+            "roi": "FULL_FRAME",
+            "gratingConfig": null,
+            "filterS": null,
+            "fpu": null
+          },
+          "stepConfig": {
+            "stepType": "SCIENCE",
+            "offset": {
+              "p": {
+                "microarcseconds": 0
+              },
+              "q": {
+                "microarcseconds": 0
+              }
+            }
+          },
+          "stepEvents": [
+            {
+              "id": "e-5",
+              "received": "2022-08-22T18:26:42.092Z",
+              "payload": {
+                "sequenceType": "SCIENCE",
+                "stepStage": "END_STEP"
+              }
+            },
+            {
+              "id": "e-4",
+              "received": "2022-08-22T18:26:36.809Z",
+              "payload": {
+                "sequenceType": "SCIENCE",
+                "stepStage": "START_STEP"
+              }
+            }
+          ],
+          "stepQaState": null,
+          "datasetEvents": [],
+          "datasets": []
+        }
+      ],
+      "sequenceEvents": [
+        {
+          "id": "e-2",
+          "received": "2022-08-22T18:18:56.336Z",
+          "payload": {
+            "command": "START"
+          }
+        },
+        {
+          "id": "e-3",
+          "received": "2022-08-22T18:20:42.047Z",
+          "payload": {
+            "command": "STOP"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/lucuma-schemas/src/test/resources/visitsQuery.graphql
+++ b/lucuma-schemas/src/test/resources/visitsQuery.graphql
@@ -1,0 +1,221 @@
+query {
+  observations {
+    matches {
+    	id
+      execution {
+        executionConfig {
+          ...on GmosNorthExecutionConfig {
+            visits {
+              id
+              created
+              startTime
+              endTime
+              duration {
+                microseconds
+              }
+              staticConfigN:staticConfig {
+                stageMode
+                detector
+                mosPreImaging
+              }
+              steps {
+                id
+                created
+                startTime
+                endTime
+                duration {
+                  microseconds
+                }
+                instrumentConfig {
+                  exposure {
+                    microseconds
+                  }
+                  readout {
+                    xBin
+                    yBin
+                    ampCount
+                    ampGain
+                    ampReadMode
+                  }
+                  dtax
+                  roi
+                  gratingConfig {
+                    gratingN:grating
+                    order
+                    wavelength {
+                      picometers
+                    }
+                  }
+                  filterN:filter
+                  fpu {
+                    customMask {
+                      filename
+                      slitWidth
+                    }
+                    builtinN:builtin
+                  }
+                }
+                stepConfig {
+                  stepType
+                  ...on Gcal {
+                    continuum
+                    arcs
+                    filter
+                    diffuser
+                    shutter
+                  }
+                  ...on Science {
+                    offset {
+                      p {
+                        microarcseconds
+                      }
+                      q {
+                        microarcseconds
+                      }
+                    }
+                    
+                  }
+                }
+                stepEvents {
+                  id
+                  received
+                  payload {
+                    sequenceType
+                    stepStage
+                  }
+                }
+                stepQaState
+                datasetEvents {
+                  id
+                  received
+                  datasetId {
+                    index
+                  }
+                }
+                datasets {
+                  id {
+                    index
+                  }
+                  filename
+                  qaState
+                }
+              }
+              sequenceEvents {
+                id
+                received
+                payload {
+                  command
+                }
+              }              
+            }
+          }
+          ...on GmosSouthExecutionConfig {
+            visits {
+              id
+              created
+              startTime
+              endTime
+              duration {
+                microseconds
+              }             
+              staticConfigS:staticConfig {
+                stageMode
+                detector
+                mosPreImaging
+              }
+              steps {
+                id
+                created
+                startTime
+                endTime
+                duration {
+                  microseconds
+                }
+                instrumentConfig {
+                  exposure {
+                    microseconds
+                  }
+                  readout {
+                    xBin
+                    yBin
+                    ampCount
+                    ampGain
+                    ampReadMode
+                  }
+                  dtax
+                  roi
+                  gratingConfig {
+                    gratingS:grating
+                    order
+                    wavelength {
+                      picometers
+                    }
+                  }
+                  filterS:filter
+                  fpu {
+                    customMask {
+                      filename
+                      slitWidth
+                    }
+                    builtinS:builtin
+                  }
+                }
+                stepConfig {
+                  stepType
+                  ...on Gcal {
+                    continuum
+                    arcs
+                    filter
+                    diffuser
+                    shutter
+                  }
+                  ...on Science {
+                    offset {
+                      p {
+                        microarcseconds
+                      }
+                      q {
+                        microarcseconds
+                      }
+                    }
+                    
+                  }
+                }
+                stepEvents {
+                  id
+                  received
+                  payload {
+                    sequenceType
+                    stepStage
+                  }
+                }
+                stepQaState
+                datasetEvents {
+                  id
+                  received
+                  datasetId {
+                    index
+                  }
+                }
+                datasets {
+                  id {
+                    index
+                  }
+                  filename
+                  qaState
+                }
+              }
+              sequenceEvents {
+                id
+                received
+                payload {
+                  command
+                }
+              }
+            }
+          }          
+        }
+      }
+    }
+  }
+}

--- a/lucuma-schemas/src/test/scala/lucuma/schemas/decoders/VisitDecodersSuite.scala
+++ b/lucuma-schemas/src/test/scala/lucuma/schemas/decoders/VisitDecodersSuite.scala
@@ -1,0 +1,119 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.schemas.decoders
+
+import cats.effect.IO
+import cats.syntax.all.{_, given}
+import lucuma.core.enums.GmosAmpCount
+import lucuma.core.enums.GmosAmpGain
+import lucuma.core.enums.GmosAmpReadMode
+import lucuma.core.enums.GmosDtax
+import lucuma.core.enums.GmosRoi
+import lucuma.core.enums.GmosSouthDetector
+import lucuma.core.enums.GmosSouthStageMode
+import lucuma.core.enums.GmosXBinning
+import lucuma.core.enums.GmosYBinning
+import lucuma.core.enums.MosPreImaging
+import lucuma.core.enums.SequenceCommand
+import lucuma.core.enums.SequenceType
+import lucuma.core.enums.StepStage
+import lucuma.core.math.Offset
+import lucuma.core.model.ExecutionEvent
+import lucuma.core.model.NonNegDuration
+import lucuma.core.model.sequence.DynamicConfig
+import lucuma.core.model.sequence.GmosCcdMode
+import lucuma.core.model.sequence.StaticConfig
+import lucuma.core.model.sequence.Step
+import lucuma.core.model.sequence.StepConfig
+import lucuma.refined.*
+import lucuma.refined.*
+import lucuma.schemas.model.SequenceEvent
+import lucuma.schemas.model.StepEvent
+import lucuma.schemas.model.StepRecord
+import lucuma.schemas.model.Visit
+
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+class VisitDecodersSuite extends InputStreamSuite {
+  val expectedVisits: List[Visit] = List(
+    Visit.GmosSouth(
+      id = Visit.Id.fromUuid(UUID.fromString("7d093b73-3ac7-4886-bb34-0005bcb53ba4")),
+      created = Instant.parse("2022-08-22T18:18:46.236929950Z"),
+      startTime = Instant.parse("2022-08-22T18:18:56.336Z").some,
+      endTime = Instant.parse("2022-08-22T18:26:36.809Z").some,
+      duration = NonNegDuration.unsafeFrom(Duration.ofNanos(460473000000L)).some,
+      staticConfig = StaticConfig.GmosSouth(
+        GmosSouthStageMode.FollowXy,
+        GmosSouthDetector.Hamamatsu,
+        MosPreImaging.IsNotMosPreImaging,
+        none
+      ),
+      steps = List(
+        StepRecord.GmosSouth(
+          id = Step.Id.fromUuid(UUID.fromString("f1214814-93c8-4cdb-848b-8a69e61fc754")),
+          created = Instant.parse("2022-08-22T18:19:03.230191206Z"),
+          startTime = Instant.parse("2022-08-22T18:26:42.092Z").some,
+          endTime = Instant.parse("2022-08-22T18:26:36.809Z").some,
+          duration = NonNegDuration.zero.some,
+          instrumentConfig = DynamicConfig.GmosSouth(
+            exposure = Duration.ofNanos(120000000000L),
+            readout = GmosCcdMode(
+              xBin = GmosXBinning.One,
+              yBin = GmosYBinning.One,
+              ampCount = GmosAmpCount.Three,
+              ampGain = GmosAmpGain.Low,
+              ampReadMode = GmosAmpReadMode.Slow
+            ),
+            dtax = GmosDtax.Zero,
+            roi = GmosRoi.FullFrame,
+            gratingConfig = none,
+            filter = none,
+            fpu = none
+          ),
+          stepConfig = StepConfig.Science(Offset(Offset.P.Zero, Offset.Q.Zero)),
+          stepEvents = List(
+            StepEvent(
+              id = ExecutionEvent.Id(5.refined),
+              received = Instant.parse("2022-08-22T18:26:42.092Z"),
+              sequenceType = SequenceType.Science,
+              stepStage = StepStage.EndStep
+            ),
+            StepEvent(
+              id = ExecutionEvent.Id(4.refined),
+              received = Instant.parse("2022-08-22T18:26:36.809Z"),
+              sequenceType = SequenceType.Science,
+              stepStage = StepStage.StartStep
+            )
+          ),
+          stepQaState = none,
+          datasetEvents = List.empty,
+          datasets = List.empty
+        )
+      ),
+      sequenceEvents = List(
+        SequenceEvent(
+          id = ExecutionEvent.Id(2.refined),
+          received = Instant.parse("2022-08-22T18:18:56.336Z"),
+          command = SequenceCommand.Start
+        ),
+        SequenceEvent(
+          id = ExecutionEvent.Id(3.refined),
+          received = Instant.parse("2022-08-22T18:20:42.047Z"),
+          command = SequenceCommand.Stop
+        )
+      )
+    )
+  )
+
+  test("Visits decoder") {
+    jsonResult("/v1.json")
+      .map(_.hcursor.downField("visits"))
+      .map(_.as[List[Visit]])
+      .flatMap(IO.fromEither)
+      .map(visits => assertEquals(visits, expectedVisits))
+  }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("edu.gemini"   % "sbt-lucuma-lib"    % "0.9.4")
-addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.0")
+addSbtPlugin("edu.gemini" % "sbt-lucuma-lib" % "0.9.4")

--- a/templates/src/main/scala/lucuma/schemas/ObservationDB.scala
+++ b/templates/src/main/scala/lucuma/schemas/ObservationDB.scala
@@ -8,7 +8,6 @@ import lucuma.core.enums
 import lucuma.core.model
 import lucuma.core.model._
 import lucuma.core.model.sequence._
-import lucuma.core.math
 import lucuma.core.math.dimensional._
 import lucuma.core.math.BrightnessUnits._
 // gql: import io.circe.refined._
@@ -52,6 +51,7 @@ trait ObservationDB {
     type CatalogName                         = enums.CatalogName
     type CloudExtinction                     = enums.CloudExtinction
     type CoolStarTemperature                 = enums.CoolStarTemperature
+    type DatasetQaState                      = enums.DatasetQaState
     type DatasetStage                        = enums.DatasetStage
     type EphemerisKeyType                    = enums.EphemerisKeyType
     type FluxDensityContinuumIntegratedUnits = Units Of FluxDensityContinuum[Integrated]
@@ -100,51 +100,11 @@ trait ObservationDB {
     type SkyBackground                       = enums.SkyBackground
     type SpectroscopyCapabilities            = enums.SpectroscopyCapabilities
     type StellarLibrarySpectrum              = enums.StellarLibrarySpectrum
+    type StepQaState                         = enums.StepQaState
     type StepStage                           = enums.StepStage
     type StepType                            = enums.StepType
     type TacCategory                         = enums.TacCategory
     type ToOActivation                       = enums.ToOActivation
     type WaterVapor                          = enums.WaterVapor
-  }
-
-  object Types {
-    type BandNormalizedIntegrated       = model.SpectralDefinition.BandNormalized[Integrated]
-    type BandNormalizedSurface          = model.SpectralDefinition.BandNormalized[Surface]
-    type BrightnessIntegrated           = Measure[BigDecimal] Of Brightness[Integrated]
-    type BrightnessSurface              = Measure[BigDecimal] Of Brightness[Surface]
-    type BlackBody                      = model.UnnormalizedSED.BlackBody
-    type CoolStarModel                  = model.UnnormalizedSED.CoolStarModel
-    type Coordinates                    = math.Coordinates
-    type Declination                    = math.Declination
-    type Duration                       = java.time.Duration
-    type EmissionLineIntegrated         = model.EmissionLine[Integrated]
-    type EmissionLineSurface            = model.EmissionLine[Surface]
-    type EmissionLinesIntegrated        = model.SpectralDefinition.EmissionLines[Integrated]
-    type EmissionLinesSurface           = model.SpectralDefinition.EmissionLines[Surface]
-    type FluxDensityContinuumIntegrated = Measure[BigDecimal] Of FluxDensityContinuum[Integrated]
-    type FluxDensityContinuumSurface    = Measure[BigDecimal] Of FluxDensityContinuum[Surface]
-    type Galaxy                         = model.UnnormalizedSED.Galaxy
-    type GaussianSource                 = model.SourceProfile.Gaussian
-    type HiiRegion                      = model.UnnormalizedSED.HIIRegion
-    type LineFluxIntegrated             = Measure[BigDecimal] Of LineFlux[Integrated]
-    type LineFluxSurface                = Measure[BigDecimal] Of LineFlux[Surface]
-    type Parallax                       = math.Parallax
-    type Planet                         = model.UnnormalizedSED.Planet
-    type PlanetaryNebula                = model.UnnormalizedSED.PlanetaryNebula
-    type PointSource                    = model.SourceProfile.Point
-    type PosAngleConstraint             = model.PosAngleConstraint
-    type PowerLaw                       = model.UnnormalizedSED.PowerLaw
-    type ProperMotion                   = math.ProperMotion
-    type ProperMotionDeclination        = math.ProperMotion.Dec
-    type ProperMotionRA                 = math.ProperMotion.RA
-    type Proposal                       = model.Proposal
-    type Quasar                         = model.UnnormalizedSED.Quasar
-    type RadialVelocity                 = math.RadialVelocity
-    type RightAscension                 = math.RightAscension
-    type Sidereal                       = model.SiderealTracking
-    type StellarLibrary                 = model.UnnormalizedSED.StellarLibrary
-    type UniformSource                  = model.SourceProfile.Uniform
-    type UserDefined                    = model.UnnormalizedSED.UserDefined
-    type Wavelength                     = math.Wavelength
   }
 }


### PR DESCRIPTION
This PR introduces a read-only model for `Visit` and related types. To make the model read-only, constructors are protected to `schemas`. Also, lenses are omitted.

Also, the build is now Scala 3 only.

Unnecessary type mappings are removed from `ObservationDB` template. (`Types` section is only helpful for GQL's input types).