### PR TITLE
Visit/StepRecord model refactor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val munitCatsEffectVersion = "1.0.7"
 val lucumaCoreVersion      = "0.82.0"
 val lucumaODBSchema        = "0.4.0"
 
-ThisBuild / tlBaseVersion       := "0.56"
+ThisBuild / tlBaseVersion       := "0.57"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / crossScalaVersions  := Seq("3.3.0")
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.29.0")

--- a/lucuma-schemas/src/test/scala/lucuma/schemas/decoders/VisitDecodersSuite.scala
+++ b/lucuma-schemas/src/test/scala/lucuma/schemas/decoders/VisitDecodersSuite.scala
@@ -40,7 +40,7 @@ import java.time.Instant
 import java.util.UUID
 
 class VisitDecodersSuite extends InputStreamSuite {
-  val expectedVisits: List[Visit] = List(
+  val expectedVisits: List[Visit.GmosSouth] = List(
     Visit.GmosSouth(
       id = Visit.Id.fromUuid(UUID.fromString("7d093b73-3ac7-4886-bb34-0005bcb53ba4")),
       created = Instant.parse("2022-08-22T18:18:46.236929950Z"),
@@ -119,7 +119,7 @@ class VisitDecodersSuite extends InputStreamSuite {
   test("Visits decoder") {
     jsonResult("/v1.json")
       .map(_.hcursor.downField("visits"))
-      .map(_.as[List[Visit]])
+      .map(_.as[List[Visit.GmosSouth]])
       .flatMap(IO.fromEither)
       .map(visits => assertEquals(visits, expectedVisits))
   }

--- a/model/src/main/scala/lucuma/schemas/decoders/VisitDecoders.scala
+++ b/model/src/main/scala/lucuma/schemas/decoders/VisitDecoders.scala
@@ -171,20 +171,16 @@ trait VisitDecoders:
     )
   )
 
-  given Decoder[Visit] =
-    List[Decoder[Visit]](
-      Decoder[Visit.GmosNorth].widen,
-      Decoder[Visit.GmosSouth].widen
-    ).reduceLeft(_ or _)
-
   given decoderExecutionVisitsGmosNorth: Decoder[ExecutionVisits.GmosNorth] = semiauto.deriveDecoder
 
   given decoderExecutionVisitsGmosSouth: Decoder[ExecutionVisits.GmosSouth] = semiauto.deriveDecoder
 
-  given Decoder[ExecutionVisits] = Decoder.instance(c =>
-    c.downField("instrument").as[Instrument].flatMap {
-      case Instrument.GmosNorth => c.as[ExecutionVisits.GmosNorth]
-      case Instrument.GmosSouth => c.as[ExecutionVisits.GmosSouth]
-      case _                    => DecodingFailure("Only Gmos supported", c.history).asLeft
-    }
-  )
+  given Decoder[InstrumentExecutionVisits] = Decoder.instance: c =>
+    c.downField("instrument")
+      .as[Instrument]
+      .flatMap:
+        case Instrument.GmosNorth =>
+          c.as[ExecutionVisits.GmosNorth].map(InstrumentExecutionVisits.GmosNorth(_))
+        case Instrument.GmosSouth =>
+          c.as[ExecutionVisits.GmosSouth].map(InstrumentExecutionVisits.GmosSouth(_))
+        case _                    => DecodingFailure("Only Gmos supported", c.history).asLeft

--- a/model/src/main/scala/lucuma/schemas/model/ExecutionVisits.scala
+++ b/model/src/main/scala/lucuma/schemas/model/ExecutionVisits.scala
@@ -3,9 +3,14 @@
 
 package lucuma.schemas.model
 
-trait ExecutionVisits:
-  def visits: List[Visit]
+import lucuma.core.model.sequence.gmos.DynamicConfig
+import lucuma.core.model.sequence.gmos.StaticConfig
+
+trait ExecutionVisits[S, D]:
+  def visits: List[Visit[S, D]]
 
 object ExecutionVisits:
-  case class GmosNorth(visits: List[Visit.GmosNorth]) extends ExecutionVisits
-  case class GmosSouth(visits: List[Visit.GmosSouth]) extends ExecutionVisits
+  case class GmosNorth(visits: List[Visit.GmosNorth])
+      extends ExecutionVisits[StaticConfig.GmosNorth, DynamicConfig.GmosNorth]
+  case class GmosSouth(visits: List[Visit.GmosSouth])
+      extends ExecutionVisits[StaticConfig.GmosSouth, DynamicConfig.GmosSouth]

--- a/model/src/main/scala/lucuma/schemas/model/InstrumentExecutionVisits.scala
+++ b/model/src/main/scala/lucuma/schemas/model/InstrumentExecutionVisits.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.schemas.model
+
+import lucuma.core.enums.Instrument
+
+sealed trait InstrumentExecutionVisits(val instrument: Instrument)
+
+object InstrumentExecutionVisits:
+  case class GmosNorth(executionVisits: ExecutionVisits.GmosNorth)
+      extends InstrumentExecutionVisits(Instrument.GmosNorth)
+
+  case class GmosSouth(executionVisits: ExecutionVisits.GmosSouth)
+      extends InstrumentExecutionVisits(Instrument.GmosSouth)

--- a/model/src/main/scala/lucuma/schemas/model/StepRecord.scala
+++ b/model/src/main/scala/lucuma/schemas/model/StepRecord.scala
@@ -14,13 +14,13 @@ import org.typelevel.cats.time.given
 
 import java.time.Instant
 
-sealed trait StepRecord derives Eq:
+sealed trait StepRecord[D] derives Eq:
   def id: Step.Id
   def created: Instant
   def startTime: Option[Instant]
   def endTime: Option[Instant]
   def duration: Option[TimeSpan]
-  def instrumentConfig: DynamicConfig
+  def instrumentConfig: D
   def stepConfig: StepConfig
   def stepEvents: List[StepEvent]
   def stepQaState: Option[StepQaState]
@@ -40,7 +40,7 @@ object StepRecord:
     stepQaState:      Option[StepQaState],
     datasetEvents:    List[DatasetEvent],
     datasets:         List[Dataset]
-  ) extends StepRecord
+  ) extends StepRecord[DynamicConfig.GmosNorth]
       derives Eq
 
   case class GmosSouth protected[schemas] (
@@ -55,5 +55,5 @@ object StepRecord:
     stepQaState:      Option[StepQaState],
     datasetEvents:    List[DatasetEvent],
     datasets:         List[Dataset]
-  ) extends StepRecord
+  ) extends StepRecord[DynamicConfig.GmosSouth]
       derives Eq

--- a/model/src/main/scala/lucuma/schemas/model/Visit.scala
+++ b/model/src/main/scala/lucuma/schemas/model/Visit.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.derived.*
 import cats.syntax.all.given
 import lucuma.core.enums.SequenceType
+import lucuma.core.model.sequence.gmos.DynamicConfig
 import lucuma.core.model.sequence.gmos.StaticConfig
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.WithUid
@@ -15,22 +16,22 @@ import org.typelevel.cats.time.given
 
 import java.time.Instant
 
-sealed trait Visit derives Eq:
+sealed trait Visit[S, D] derives Eq:
   def id: Visit.Id
   def created: Instant
   def startTime: Option[Instant]
   def endTime: Option[Instant]
   def duration: Option[TimeSpan]
-  def staticConfig: StaticConfig
-  def steps: List[StepRecord]
+  def staticConfig: S
+  def steps: List[StepRecord[D]]
   def sequenceEvents: List[SequenceEvent]
 
   // Remove these implementations when the API supports querying by type directly.
   // See https://app.shortcut.com/lucuma/story/1853/separate-visit-steps-by-sequence-type
-  def acquisitionSteps: List[StepRecord] =
+  def acquisitionSteps: List[StepRecord[D]] =
     steps.filter(_.stepEvents.headOption.map(_.sequenceType).contains_(SequenceType.Acquisition))
 
-  def scienceSteps: List[StepRecord] =
+  def scienceSteps: List[StepRecord[D]] =
     steps.filter(_.stepEvents.headOption.map(_.sequenceType).contains_(SequenceType.Science))
 
 object Visit extends WithUid('v'.refined):
@@ -43,7 +44,7 @@ object Visit extends WithUid('v'.refined):
     staticConfig:   StaticConfig.GmosNorth,
     steps:          List[StepRecord.GmosNorth],
     sequenceEvents: List[SequenceEvent]
-  ) extends Visit
+  ) extends Visit[StaticConfig.GmosNorth, DynamicConfig.GmosNorth]
       derives Eq
 
   final case class GmosSouth protected[schemas] (
@@ -55,5 +56,5 @@ object Visit extends WithUid('v'.refined):
     staticConfig:   StaticConfig.GmosSouth,
     steps:          List[StepRecord.GmosSouth],
     sequenceEvents: List[SequenceEvent]
-  ) extends Visit
+  ) extends Visit[StaticConfig.GmosSouth, DynamicConfig.GmosSouth]
       derives Eq


### PR DESCRIPTION
Refactor the `Visit`/`StepRecord` model to be coherent with static/dynamic configuration type parameters in the sequence model.
