### PR TITLE
Add ProposalStatus to ObservationDB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val munitCatsEffectVersion = "1.0.7"
 val lucumaCoreVersion      = "0.91.1"
 val lucumaODBSchema        = "0.10.0"
 
-ThisBuild / tlBaseVersion       := "0.70"
+ThisBuild / tlBaseVersion       := "0.71"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / crossScalaVersions  := Seq("3.3.1")
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.29.0")

--- a/lucuma-schemas/src/clue/scala/lucuma/schemas/ObservationDB.scala
+++ b/lucuma-schemas/src/clue/scala/lucuma/schemas/ObservationDB.scala
@@ -60,6 +60,7 @@ trait ObservationDB {
     // Enumerated instances, but this prevents a spurious codec from being generated.
     type ObsAttachmentTypeMeta      = lucuma.schemas.enums.ObsAttachmentType
     type ProposalAttachmentTypeMeta = lucuma.schemas.enums.ProposalAttachmentType
+    type ProposalStatusMeta         = lucuma.schemas.enums.ProposalStatus
   }
 
   object Enums {
@@ -119,6 +120,7 @@ trait ObservationDB {
     type PlanetSpectrum                      = enums.PlanetSpectrum
     type PlanetaryNebulaSpectrum             = enums.PlanetaryNebulaSpectrum
     type ProposalAttachmentType              = lucuma.schemas.enums.ProposalAttachmentType
+    type ProposalStatus                      = lucuma.schemas.enums.ProposalStatus
     type QuasarSpectrum                      = enums.QuasarSpectrum
     type ScienceMode                         = enums.ScienceMode
     type SequenceCommand                     = enums.SequenceCommand

--- a/model/src/main/scala/lucuma/schemas/enums/ProposalStatus.scala
+++ b/model/src/main/scala/lucuma/schemas/enums/ProposalStatus.scala
@@ -22,6 +22,8 @@ object ProposalStatus {
 
   lazy val NotSubmitted: ProposalStatus = Enumerated[ProposalStatus].unsafeFromTag("NOT_SUBMITTED")
   lazy val Submitted: ProposalStatus    = Enumerated[ProposalStatus].unsafeFromTag("SUBMITTED")
+  lazy val Accepted: ProposalStatus     = Enumerated[ProposalStatus].unsafeFromTag("ACCEPTED")
+  lazy val NotAccepted: ProposalStatus  = Enumerated[ProposalStatus].unsafeFromTag("NOT_ACCEPTED")
 
   given Enumerated[ProposalStatus] =
     DynamicEnums.enumeratedInstance[ProposalStatus]("proposalStatusMeta", _.tag)(using


### PR DESCRIPTION
I forgot to do this when I added ProposalStatus... 

Also adds explicit references to the rest of the ProposalStatus enum values.