### PR TITLE
Use graphql package instead of graphqurl

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'sunday'

--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install graphqurl
-        run: npm install -g graphqurl
+          cache: npm
+      - run: npm ci
       - name: Fetch latest ODB schema
-        run: ./fetchODBSchema.sh dev
+        run: ./fetchODBSchema.mjs dev
         env:
           ODB_API_KEY: ${{ secrets.LUCUMA_DEV_API_KEY }}
       - name: Create Pull Request

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The purpose of this project is to emit an artifact that:
 
 Contains:
 
-- Schema files in `resources` (eg: `ObservationDB.graphql`). They can be updated with `fetchODBSchema.sh`. Use the `flake.nix` with `nix develop`, or install [graphqurl](https://www.npmjs.com/package/graphqurl) globally to use.
+- Schema files in `resources` (eg: `ObservationDB.graphql`). They can be updated with `fetchODBSchema.mjs`. Use the `flake.nix` with `nix develop`, and run `npm install` to use.
 - Templates (eg: `ObservationDB.scala`) to map schema scalars and other types to Scala types.
 
 ### Project `lucuma-schemas`

--- a/fetchODBSchema.mjs
+++ b/fetchODBSchema.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { writeFile } from 'fs/promises';
+import { buildClientSchema, getIntrospectionQuery, printSchema } from 'graphql';
+
+//
+// fetchODBSchema.mjs
+//
+// Usage: fetchODBSchema.mjs [local|dev|staging]
+//
+// Fetches the current version of the ODB schema from either a 'local' ODB
+// instance running on localhost, or else from the 'dev' or 'staging' ODB.  Places it
+// in the proper place in `lucuma-schemas` for use in generating code.
+//
+
+const KEY_MESSAGE = `
+Define the ODB_API_KEY environment variable to use this script. For example:
+
+  export ODB_API_KEY="111.4ed718065f21a8f01014c8d08db2c0f74fe3e860ae25bb1f03c5ae4c5e2d0a0e677e6e781a086d0a6638960506cff7db"
+
+You can get an API key from the Explore "User Preferences" menu item in Explore.`;
+
+const RED = '\x1b[0;31m';
+const NC = '\x1b[0m';
+
+if (!process.env.ODB_API_KEY) {
+  console.error(`${RED}${KEY_MESSAGE}${NC}`);
+  process.exit(1);
+}
+
+function usage() {
+  console.error(`${RED}Usage: ${process.argv[1]} [local|dev|staging]${NC}`);
+  process.exit(1);
+}
+
+let url;
+
+// [2] is the first arg (after node and the script name)
+switch (process.argv[2]) {
+  case 'local':
+    url = 'http://localhost:8082/odb';
+    break;
+  case 'dev':
+    url = 'https://lucuma-postgres-odb-dev.herokuapp.com/odb';
+    break;
+  case 'staging':
+    url = 'https://lucuma-postgres-odb-staging.herokuapp.com/odb';
+    break;
+
+  default:
+    usage();
+    break;
+}
+
+const response = await fetch(new URL(url), {
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.ODB_API_KEY}`,
+  },
+  method: 'POST',
+  body: JSON.stringify({ query: getIntrospectionQuery() }),
+});
+
+if (!response.ok) {
+  throw new Error(
+    `Failed to fetch introspection query: ${response.statusText}`
+  );
+}
+
+console.log('Fetched ODB schema.');
+
+const data = (await response.json()).data;
+
+const schema = printSchema(buildClientSchema(data));
+
+await writeFile(
+  'lucuma-schemas/src/clue/resources/lucuma/schemas/ObservationDB.graphql',
+  schema
+);
+
+console.log('Wrote ODB schema to lucuma-schemas.');

--- a/fetchODBSchema.sh
+++ b/fetchODBSchema.sh
@@ -1,52 +1,5 @@
 #!/bin/bash
 
-#
-# fetchODBSchema.sh
-#
-# Usage: sh fetchODBSchema.sh [local|dev|staging]
-#
-# Fetches the current version of the ODB schema from either a 'local' ODB
-# instance running on localhost, or else from the 'dev' or 'staging' ODB.  Places it
-# in the proper place in `lucuma-schemas` for use in generating code.
-#
+npm ci
 
-KEY_MESSAGE=$(cat << END
-Define the ODB_API_KEY environment variable to use this script. For example:
-
-  export ODB_API_KEY="111.4ed718065f21a8f01014c8d08db2c0f74fe3e860ae25bb1f03c5ae4c5e2d0a0e677e6e781a086d0a6638960506cff7db"
-
-You can get an API key from the Explore "User Preferences" menu item in Explore.
-
-END
-)
-
-RED='\033[0;31m'
-NC='\033[0m'
-
-if [ -z "${ODB_API_KEY}" ]; then
-  echo -e "${RED}$KEY_MESSAGE${NC}"
-  exit 1
-fi
-
-function usage {
-  echo -e "${RED}Usage: $0 [local|dev|staging]${NC}"
-  exit 1
-}
-
-case "$1" in
-  local)
-    URL="http://localhost:8082/odb"
-    ;;
-  dev)
-    URL="https://lucuma-postgres-odb-dev.herokuapp.com/odb"
-    ;;
-  staging)
-    URL="https://lucuma-postgres-odb-staging.herokuapp.com/odb"
-    ;;
-  *)
-    usage
-    ;;
-esac
-
-
-gq $URL -H "Authorization: Bearer ${ODB_API_KEY}" --introspect >lucuma-schemas/src/clue/resources/lucuma/schemas/ObservationDB.graphql
+./fetchODBSchema.mjs $@

--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,6 @@
       in {
         devShell = pkgs.devshell.mkShell {
           imports = [ typelevel-nix.typelevelShell ];
-          packages = [
-            pkgs.nodePackages.graphqurl
-          ];
           typelevelShell = {
             nodejs.enable = true;
             jdk.package = pkgs.jdk17;

--- a/lucuma-schemas/src/clue/resources/lucuma/schemas/ObservationDB.graphql
+++ b/lucuma-schemas/src/clue/resources/lucuma/schemas/ObservationDB.graphql
@@ -8737,4 +8737,3 @@ scalar BigDecimal
 The `Long` scalar type represents non-fractional signed whole numeric values. Long can represent values between -(2^63) and 2^63 - 1.
 """
 scalar Long
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "lucuma-schemas",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lucuma-schemas",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "graphql": "^16.8.1"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "lucuma-schemas",
+  "version": "1.0.0",
+  "private": true,
+  "main": "fetchODBSchema.mjs",
+  "description": "Fetch ODB schema",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "start": "./fetchODBSchema.mjs"
+  },
+  "license": "BSD-3-Clause",
+  "devDependencies": {
+    "graphql": "^16.8.1"
+  }
+}


### PR DESCRIPTION
Graphqurl has not been updated in a while and has some open security warnings. We can replace it with a simple script using the graphql node library.
