### PR TITLE
Skip config in visits query

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,4 @@
 include ".scalafix-common.conf"
 GraphQLGen.schemaDirs=["lucuma-schemas/src/clue/resources/lucuma/schemas"]
 OrganizeImports.removeUnused = true
+OrganizeImports.targetDialect = Scala3

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val Versions = new { // sbt doesn't like object definitions in build.sbt
   val munitCatsEffect = "2.0.0"
 }
 
-ThisBuild / tlBaseVersion       := "0.101"
+ThisBuild / tlBaseVersion       := "0.102"
 ThisBuild / tlCiReleaseBranches := Seq("main")
 ThisBuild / crossScalaVersions  := Seq("3.5.1")
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.29.0")

--- a/lucuma-schemas/src/main/scala/lucuma/schemas/odb/ExecutionVisitsSubquery.scala
+++ b/lucuma-schemas/src/main/scala/lucuma/schemas/odb/ExecutionVisitsSubquery.scala
@@ -12,29 +12,6 @@ object ExecutionVisitsSubquery
     extends GraphQLSubquery.Typed[ObservationDB, Option[ExecutionVisits]]("Execution"):
   override val subquery: String = s"""
     {
-      config {
-        instrument
-        gmosNorth {
-          static {
-            stageMode
-            detector
-            mosPreImaging
-            nodAndShuffle {
-              ...nodAndShuffleFields
-            }
-          }
-        }
-        gmosSouth {
-          static {
-            stageMode
-            detector
-            mosPreImaging
-            nodAndShuffle {
-              ...nodAndShuffleFields
-            }
-          }
-        }
-      }
       visits(OFFSET: $$visitIdOffset) {
         matches {
           id

--- a/lucuma-schemas/src/test/resources/visitGmosNorth.json
+++ b/lucuma-schemas/src/test/resources/visitGmosNorth.json
@@ -1,17 +1,6 @@
 {
   "observation": {
     "execution": {
-      "config": {
-        "instrument": "GMOS_NORTH",
-        "gmosNorth": {
-          "static": {
-            "stageMode": "FOLLOW_XY",
-            "detector": "HAMAMATSU",
-            "mosPreImaging": "IS_NOT_MOS_PRE_IMAGING",
-            "nodAndShuffle": null
-          }
-        }
-      },
       "visits": {
         "matches": [
           {

--- a/lucuma-schemas/src/test/resources/visitGmosSouth.json
+++ b/lucuma-schemas/src/test/resources/visitGmosSouth.json
@@ -1,17 +1,6 @@
 {
   "observation": {
     "execution": {
-      "config": {
-        "instrument": "GMOS_SOUTH",
-        "gmosSouth": {
-          "static": {
-            "stageMode": "FOLLOW_XY",
-            "detector": "HAMAMATSU",
-            "mosPreImaging": "IS_NOT_MOS_PRE_IMAGING",
-            "nodAndShuffle": null
-          }
-        }
-      },
       "visits": {
         "matches": [
           {

--- a/lucuma-schemas/src/test/resources/visitNoSequence.json
+++ b/lucuma-schemas/src/test/resources/visitNoSequence.json
@@ -1,7 +1,6 @@
 {
   "observation": {
     "execution": {
-      "config": null,
       "visits": {
         "matches": []
       }

--- a/lucuma-schemas/src/test/resources/visitsQuery.graphql
+++ b/lucuma-schemas/src/test/resources/visitsQuery.graphql
@@ -1,15 +1,5 @@
 query {
   observation(observationId: "o-14d") {
-    execution {
-      config {
-        instrument
-        gmosNorth {
-          ...gmosNorthStaticConfigFields
-        }
-        gmosSouth {
-          ...gmosSouthStaticConfigFields
-        }
-      }
       visits {
         matches {
           id

--- a/lucuma-schemas/src/test/scala/lucuma/schemas/decoders/VisitDecodersSuite.scala
+++ b/lucuma-schemas/src/test/scala/lucuma/schemas/decoders/VisitDecodersSuite.scala
@@ -3,22 +3,18 @@
 
 package lucuma.schemas.decoders
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.syntax.all.*
 import lucuma.core.enums.GmosAmpCount
 import lucuma.core.enums.GmosAmpGain
 import lucuma.core.enums.GmosAmpReadMode
 import lucuma.core.enums.GmosDtax
-import lucuma.core.enums.GmosNorthDetector
 import lucuma.core.enums.GmosNorthFilter
-import lucuma.core.enums.GmosNorthStageMode
 import lucuma.core.enums.GmosRoi
-import lucuma.core.enums.GmosSouthDetector
 import lucuma.core.enums.GmosSouthFilter
-import lucuma.core.enums.GmosSouthStageMode
 import lucuma.core.enums.GmosXBinning
 import lucuma.core.enums.GmosYBinning
-import lucuma.core.enums.MosPreImaging
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
 import lucuma.core.enums.StepGuideState
@@ -42,13 +38,7 @@ import java.util.UUID
 
 class VisitDecodersSuite extends InputStreamSuite {
   val expectedVisitsGmosNorth: ExecutionVisits = ExecutionVisits.GmosNorth(
-    StaticConfig.GmosNorth(
-      stageMode = GmosNorthStageMode.FollowXy,
-      detector = GmosNorthDetector.Hamamatsu,
-      mosPreImaging = MosPreImaging.IsNotMosPreImaging,
-      nodAndShuffle = none
-    ),
-    List(
+    NonEmptyList.of(
       Visit.GmosNorth(
         id = Visit.Id(457L.refined),
         created =
@@ -129,13 +119,7 @@ class VisitDecodersSuite extends InputStreamSuite {
   )
 
   val expectedVisitsGmosSouth: ExecutionVisits = ExecutionVisits.GmosSouth(
-    StaticConfig.GmosSouth(
-      stageMode = GmosSouthStageMode.FollowXy,
-      detector = GmosSouthDetector.Hamamatsu,
-      mosPreImaging = MosPreImaging.IsNotMosPreImaging,
-      nodAndShuffle = none
-    ),
-    List(
+    NonEmptyList.of(
       Visit.GmosSouth(
         id = Visit.Id(457L.refined),
         created =

--- a/model/src/main/scala/lucuma/schemas/model/ExecutionVisits.scala
+++ b/model/src/main/scala/lucuma/schemas/model/ExecutionVisits.scala
@@ -4,10 +4,10 @@
 package lucuma.schemas.model
 
 import cats.Eq
+import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.eq.*
 import lucuma.core.enums.Instrument
-import lucuma.core.model.sequence.gmos.StaticConfig
 import monocle.Focus
 import monocle.Lens
 import monocle.Prism
@@ -16,32 +16,30 @@ import monocle.macros.GenPrism
 enum ExecutionVisits(val instrument: Instrument) derives Eq:
 
   private def removeDuplicateVisitOverlap[D, V <: Visit[D]](
-    left:  List[V],
-    right: List[V]
-  ): List[V] =
-    left.takeWhile: v =>
-      right.headOption.forall(_.id =!= v.id)
-    ++ right
+    left:  NonEmptyList[V],
+    right: NonEmptyList[V]
+  ): NonEmptyList[V] =
+    NonEmptyList
+      .fromList:
+        left.toList.takeWhile: v =>
+          right.head.id =!= v.id
+      .fold(right)(_ ++ right.toList)
 
   def extendWith(other: ExecutionVisits): ExecutionVisits =
     (this, other) match
-      case (GmosNorth(leftConfig, leftVisits), GmosNorth(_, rightVisits)) =>
-        GmosNorth(leftConfig, removeDuplicateVisitOverlap(leftVisits, rightVisits))
-      case (GmosSouth(leftConfig, leftVisits), GmosSouth(_, rightVisits)) =>
-        GmosSouth(leftConfig, removeDuplicateVisitOverlap(leftVisits, rightVisits))
-      case (left, right)                                                  =>
+      case (GmosNorth(leftVisits), GmosNorth(rightVisits)) =>
+        GmosNorth(removeDuplicateVisitOverlap(leftVisits, rightVisits))
+      case (GmosSouth(leftVisits), GmosSouth(rightVisits)) =>
+        GmosSouth(removeDuplicateVisitOverlap(leftVisits, rightVisits))
+      case (left, right)                                   =>
         throw new Exception:
           s"Attempted to join ExecutionVisits for different instruments: ${left.instrument} and ${right.instrument}"
 
-  case GmosNorth(
-    staticConfig: StaticConfig.GmosNorth,
-    visits:       List[Visit.GmosNorth]
-  ) extends ExecutionVisits(Instrument.GmosNorth)
+  case GmosNorth(visits: NonEmptyList[Visit.GmosNorth])
+      extends ExecutionVisits(Instrument.GmosNorth)
 
-  case GmosSouth(
-    staticConfig: StaticConfig.GmosSouth,
-    visits:       List[Visit.GmosSouth]
-  ) extends ExecutionVisits(Instrument.GmosSouth)
+  case GmosSouth(visits: NonEmptyList[Visit.GmosSouth])
+      extends ExecutionVisits(Instrument.GmosSouth)
 
 object ExecutionVisits:
   val gmosNorth: Prism[ExecutionVisits, ExecutionVisits.GmosNorth] =
@@ -51,15 +49,9 @@ object ExecutionVisits:
     GenPrism[ExecutionVisits, ExecutionVisits.GmosSouth]
 
   object GmosNorth:
-    val staticConfig: Lens[GmosNorth, StaticConfig.GmosNorth] =
-      Focus[GmosNorth](_.staticConfig)
-
-    val visits: Lens[GmosNorth, List[Visit.GmosNorth]] =
+    val visits: Lens[GmosNorth, NonEmptyList[Visit.GmosNorth]] =
       Focus[GmosNorth](_.visits)
 
   object GmosSouth:
-    val staticConfig: Lens[GmosSouth, StaticConfig.GmosSouth] =
-      Focus[GmosSouth](_.staticConfig)
-
-    val visits: Lens[GmosSouth, List[Visit.GmosSouth]] =
+    val visits: Lens[GmosSouth, NonEmptyList[Visit.GmosSouth]] =
       Focus[GmosSouth](_.visits)


### PR DESCRIPTION
If, for some reason, a sequence could not be generated anymore after observation started, the previous visits query would fail.

Now we can query the visits regardless of the sequence state, resulting also in a simplified structure: the config in `ExecutionVisits` wasn't actually used anywhere.